### PR TITLE
Fixed "[muted]" when changing unmuted volume.

### DIFF
--- a/src/pulseaudio_action.c
+++ b/src/pulseaudio_action.c
@@ -170,16 +170,16 @@ void pulseaudio_set_volume_success_cb(pa_context *c, int success, void *userdata
         return;
     }
 
-    pulseaudio_update_volume_notification(mii);
+    pulseaudio_update_volume_notification(mii, 0);
 }
 
-void pulseaudio_update_volume_notification(menu_info_item_t* mii)
+void pulseaudio_update_volume_notification(menu_info_item_t* mii, int is_muting)
 {
     char vol[PA_CVOLUME_SNPRINT_MAX];
     gchar* msg = g_strdup_printf("%s %s: %s%s",
                 menu_info_type_name(mii->menu_info->type), mii->desc,
                 pa_cvolume_snprint(vol, sizeof(vol), mii->volume),
-                mii->mute ? "" : " [muted]");
+                (is_muting ^ mii->mute) ? " [muted]" : "");
 
     if(!mii->notify)
         mii->notify = notify(msg, NULL, mii->icon);
@@ -206,19 +206,19 @@ void pulseaudio_toggle_mute(menu_info_item_t* mii)
             break;
         case MENU_SINK:
             o = pa_context_set_sink_mute_by_index(context, mii->index,
-                    mute, pulseaudio_set_volume_success_cb, mii);
+                    mute, pulseaudio_toggle_mute_success_cb, mii);
             break;
         case MENU_SOURCE:
             o = pa_context_set_source_mute_by_index(context, mii->index,
-                    mute, pulseaudio_set_volume_success_cb, mii);
+                    mute, pulseaudio_toggle_mute_success_cb, mii);
             break;
         case MENU_INPUT:
             o = pa_context_set_sink_input_mute(context, mii->index,
-                    mute, pulseaudio_set_volume_success_cb, mii);
+                    mute, pulseaudio_toggle_mute_success_cb, mii);
             break;
         case MENU_OUTPUT:
             o = pa_context_set_source_output_mute(context, mii->index,
-                    mute, pulseaudio_set_volume_success_cb, mii);
+                    mute, pulseaudio_toggle_mute_success_cb, mii);
             break;
     }
     if(o)
@@ -230,6 +230,11 @@ void pulseaudio_toggle_mute_success_cb(pa_context *c, int success, void *userdat
     menu_info_item_t* mii = userdata;
 
     if(!success)
+    {
         g_error("failed to toogle mute for %s \"%s\"!\n",
                 menu_info_type_name(mii->menu_info->type), mii->name);
+        return;
+    }
+
+    pulseaudio_update_volume_notification(mii, 1);
 }

--- a/src/pulseaudio_action.h
+++ b/src/pulseaudio_action.h
@@ -37,7 +37,7 @@ void pulseaudio_rename_success_cb(pa_context *c, int success, void *userdata);
 
 void pulseaudio_volume(menu_info_item_t* mii, int inc);
 void pulseaudio_set_volume_success_cb(pa_context *c, int success, void *userdata);
-void pulseaudio_update_volume_notification(menu_info_item_t* mii);
+void pulseaudio_update_volume_notification(menu_info_item_t* mii, int is_muting);
 
 void pulseaudio_toggle_mute(menu_info_item_t* mii);
 void pulseaudio_toggle_mute_success_cb(pa_context *c, int success, void *userdata);


### PR DESCRIPTION
This bug occured with me, when I was just changing the volume, pasystray
reported the volume as muted, despite that not being the case. This is
fixed by XOR-ing a new variable called "is_muting" with the mute status.
Also used the mute callback (they were previously unused, as far as I
could tell, but were added in).
