### PR TITLE
fix string copying error

### DIFF
--- a/src/x11-property.c
+++ b/src/x11-property.c
@@ -86,7 +86,7 @@ char* x11_property_get(const char* key)
     if(actual_type != XA_STRING)
         goto finish;
 
-    value = g_memdup(prop, nitems);
+    value = g_memdup(prop, nitems + 1);
 
 #ifdef DEBUG
     g_message("[x11-property] got '%s' = '%s'", key, value);


### PR DESCRIPTION
String terminator for return value is not copied (prop[nitems]='\0').
See http://tronche.com/gui/x/xlib/window-information/XGetWindowProperty.html (XGetWindowProperty() always allocates one **extra** byte in prop_return and sets it to zero).
This fixes displayed server name. Bug does not appear under gdb or with -DDEBUG.
![pasystray](https://f.cloud.github.com/assets/1663640/1320944/219cf902-3388-11e3-996c-5378e8aa4499.png)
