### PR TITLE
Show popup if renaming a device fails

### DIFF
--- a/TODO
+++ b/TODO
@@ -6,7 +6,6 @@ fix pulseaudio reconnect
 placement of device rename dialog close to systray
 
 FEATURES:
-popup if can't rename device
 allow manual adding of servers
 module-device-manager autoload
 

--- a/src/menu_info.c
+++ b/src/menu_info.c
@@ -549,14 +549,30 @@ void menu_info_item_rename_dialog(menu_info_item_t* mii)
         char* name = g_strstrip(g_strdup(entry));
 
         if(!g_str_equal(name, mii->desc))
-            pulseaudio_rename(mii, name);
+            pulseaudio_rename(mii, name, menu_info_pulseaudio_rename_success_cb);
 
         g_free(name);
     }
 
     gtk_widget_hide(GTK_WIDGET(dialog));
-
 }
+
+void menu_info_pulseaudio_rename_success_cb(pa_context* c, int success, void* userdata)
+{
+    menu_info_item_t* mii = userdata;
+
+    // TODO: try to autoload module-device-manager?
+    if(!success)
+    {
+        GtkMessageDialog* dialog = ui_errordialog();
+        gtk_message_dialog_format_secondary_text(dialog,
+                "Failed to rename %s '%s'!\nIs module-device-manager loaded?",
+                menu_info_type_name(mii->menu_info->type), mii->name);
+
+        gtk_dialog_run(dialog);
+        gtk_widget_destroy(dialog);
+    }       
+}   
 
 void menu_info_module_unload_cb(GtkWidget* item, GdkEventButton* event, void* userdata)
 {

--- a/src/menu_info.h
+++ b/src/menu_info.h
@@ -121,6 +121,7 @@ void menu_info_subitem_clicked(GtkWidget* item, GdkEvent* event,
 
 void menu_info_item_rename_cb(GtkWidget* item, GdkEventButton* event, void* userdata);
 void menu_info_item_rename_dialog(menu_info_item_t* mii);
+void menu_info_pulseaudio_rename_success_cb(pa_context* c, int success, void* userdata);
 
 void menu_info_module_unload_cb(GtkWidget* item, GdkEventButton* event, void* userdata);
 

--- a/src/pulseaudio_action.c
+++ b/src/pulseaudio_action.c
@@ -91,7 +91,8 @@ void pulseaudio_move_success_cb(pa_context *c, int success, void *userdata)
                 menu_info_type_name(to->menu_info->type), to->name);
 }
 
-void pulseaudio_rename(menu_info_item_t* mii, const char* name)
+void pulseaudio_rename(menu_info_item_t* mii, const char* name,
+                       pa_context_success_cb_t success_callback)
 {
     g_debug("rename %s '%s' to '%s'",
             menu_info_type_name(mii->menu_info->type), mii->desc, name);
@@ -99,21 +100,11 @@ void pulseaudio_rename(menu_info_item_t* mii, const char* name)
     char *key = g_markup_printf_escaped("%s:%s", menu_info_type_name(mii->menu_info->type), mii->name);
 
     pa_operation* o;
-    if(!(o = pa_ext_device_manager_set_device_description(context, key, name, pulseaudio_rename_success_cb, mii))) {
+    if(!(o = pa_ext_device_manager_set_device_description(context, key, name, success_callback, mii))) {
         g_warning("pa_ext_device_manager_set_device_description(context, %s, %s) failed", key, name);
         return;
     }
     pa_operation_unref(o);
-}
-
-void pulseaudio_rename_success_cb(pa_context *c, int success, void *userdata)
-{
-    menu_info_item_t* mii = userdata;
-
-    // TODO: try to autoload module-device-manager?
-    if(!success)
-        g_warning("failed to rename %s '%s'! module-device-manager loaded?\n",
-                menu_info_type_name(mii->menu_info->type), mii->name);
 }
 
 void pulseaudio_volume(menu_info_item_t* mii, int inc)

--- a/src/pulseaudio_action.h
+++ b/src/pulseaudio_action.h
@@ -32,8 +32,7 @@ void pulseaudio_move_input_to_sink(menu_info_item_t* input, menu_info_item_t* si
 void pulseaudio_move_output_to_source(menu_info_item_t* output, menu_info_item_t* source);
 void pulseaudio_move_success_cb(pa_context *c, int success, void *userdata);
 
-void pulseaudio_rename(menu_info_item_t* mii, const char* name);
-void pulseaudio_rename_success_cb(pa_context *c, int success, void *userdata);
+void pulseaudio_rename(menu_info_item_t* mii, const char* name, pa_context_success_cb_t success_callback);
 
 void pulseaudio_volume(menu_info_item_t* mii, int inc);
 void pulseaudio_set_volume_success_cb(pa_context *c, int success, void *userdata);

--- a/src/ui.c
+++ b/src/ui.c
@@ -98,3 +98,11 @@ GtkEntry* ui_renamedialog_entry()
 {
     return (GtkEntry*) gtk_builder_get_object(builder, "entry");
 }
+
+GtkMessageDialog* ui_errordialog()
+{
+    GtkMessageDialog* dialog = gtk_message_dialog_new(NULL, GTK_DIALOG_MODAL,
+            GTK_MESSAGE_INFO, GTK_BUTTONS_OK, "An error occured");
+    gtk_window_set_title(GTK_WINDOW(dialog), "pasystray");
+    return dialog;
+}

--- a/src/ui.h
+++ b/src/ui.h
@@ -32,5 +32,6 @@ GtkAboutDialog* ui_aboutdialog();
 GtkDialog* ui_renamedialog();
 GtkLabel* ui_renamedialog_label();
 GtkEntry* ui_renamedialog_entry();
+GtkMessageDialog* ui_errordialog();
 
 #endif /* PASYSTRAY_UI_H */


### PR DESCRIPTION
- I moved pulseaudio_rename_success_cb into menu_info to keep the UI stuff out of pulseaudio_action
- I added ui_errordialog() to keep message dialog creation separated (don't know if it should be stored in the glade file, too)

I'm pretty sure you won't like this for several reasons. But hey, it's github and I'm here to learn!