### PR TITLE
Don't toggle mute on left-click without alt key

### DIFF
--- a/src/systray.c
+++ b/src/systray.c
@@ -336,10 +336,11 @@ void systray_click_cb(GtkStatusIcon* icon, GdkEventButton* ev, gpointer userdata
         case 1:
             /* on alt + left-click, toggle mute default sink */
             if((ev->state & GDK_MOD1_MASK) && mii)
-            {
                 pulseaudio_toggle_mute(mii);
-                break;
-            }
+            /* on left-click, show menu */
+            else
+                gtk_menu_popup(GTK_MENU(mis->menu), NULL, NULL, gtk_status_icon_position_menu, icon, ev->button, ev->time);
+            break;
         case 2:
             /* on middle-click, toggle mute default sink */
             if(mii)


### PR DESCRIPTION
Currently there is a bug with the systray left-click binding: the menu won't appear anymore and mute is always toggled, even without the alt modifier being pressed. In my original commit, the case order was 1, 3, 2, which was changed in the final merge for better readability. That order was crucial to show the menu and not toggle mute if the alt modifier wasn't pressed - hence the ```break;```.

This PR fixes that and should offer better readability than my original code.