### PR TITLE
Load error dialog from glade

### DIFF
--- a/src/pasystray.glade
+++ b/src/pasystray.glade
@@ -119,4 +119,14 @@
       <action-widget response="-5">okbutton</action-widget>
     </action-widgets>
   </object>
+  <object class="GtkMessageDialog" id="errordialog">
+    <property name="can_focus">False</property>
+    <property name="border_width">5</property>
+    <property name="resizable">False</property>
+    <property name="type_hint">dialog</property>
+    <property name="title" translatable="yes">Error</property>
+    <property name="text" translatable="yes">An error occurred</property>
+    <property name="message_type">GTK_MESSAGE_ERROR</property>
+    <property name="buttons">GTK_BUTTONS_OK</property>
+  </object>
 </interface>

--- a/src/ui.c
+++ b/src/ui.c
@@ -101,10 +101,7 @@ GtkEntry* ui_renamedialog_entry()
 
 GtkDialog* ui_errordialog(const gchar* message)
 {
-    GtkWidget* dialog = gtk_message_dialog_new(NULL, GTK_DIALOG_MODAL,
-            GTK_MESSAGE_INFO, GTK_BUTTONS_OK, "An error occured");
-    gtk_window_set_title(GTK_WINDOW(dialog), "pasystray");
-    gtk_message_dialog_format_secondary_text(GTK_MESSAGE_DIALOG(dialog), message);
-
+    GtkMessageDialog* dialog = (GtkMessageDialog*) gtk_builder_get_object(builder, "errordialog");
+    gtk_message_dialog_format_secondary_text(dialog, message);
     return GTK_DIALOG(dialog);
 }


### PR DESCRIPTION
Wasn't sure if I should return GtkMessageDialog (like GtkAboutDialog in ui_aboutdialog), but I'll leave it like that for now.

As it is an error dialog, maybe we should add some lolcats to calm down the user.