### PR TITLE
Desktop file fails validation

### DIFF
--- a/data/pasystray.desktop
+++ b/data/pasystray.desktop
@@ -8,4 +8,4 @@ Icon=pasystray
 StartupNotify=true
 Type=Application
 Categories=AudioVideo;Audio;
-Keywords=pulseaudio;tray;system tray;applet;volume
+Keywords=pulseaudio;tray;system tray;applet;volume;


### PR DESCRIPTION
The `desktop-file-validate` utility from [desktop-file-utils] reports the following error for pasystray's .desktop file:

    error: value "pulseaudio;tray;system tray;applet;volume" for locale string list key "Keywords" in group "Desktop Entry" does not have a semicolon (';') as trailing character

This PR simply fixes this error.


[desktop-file-utils]: https://wiki.freedesktop.org/www/Software/desktop-file-utils/