### PR TITLE
For upstream/notifications

### DIFF
--- a/src/menu_info.c
+++ b/src/menu_info.c
@@ -262,6 +262,10 @@ void menu_info_item_update(menu_info_t* mi, uint32_t index, const char* name,
             break;
     }
 
+    /* update sink icon */
+    if(mi->type == MENU_SINK)
+        ui_set_volume_icon(item);
+
     /* if this is the default sink, update status icon acording to volume */
     if(mi->type == MENU_SINK && item == menu_info_item_get_by_name(mi, mi->default_name))
         ui_update_systray_icon(item);

--- a/src/menu_info.c
+++ b/src/menu_info.c
@@ -254,6 +254,7 @@ void menu_info_item_update(menu_info_t* mi, uint32_t index, const char* name,
             break;
         case MENU_SINK:
         case MENU_SOURCE:
+            ui_set_volume_icon(item); // update sink item
             systray_update_item_in_all_submenus(item, submenu);
             break;
         case MENU_INPUT:
@@ -261,10 +262,6 @@ void menu_info_item_update(menu_info_t* mi, uint32_t index, const char* name,
             systray_update_all_items_in_submenu(submenu, item);
             break;
     }
-
-    /* update sink icon */
-    if(mi->type == MENU_SINK || mi->type == MENU_SOURCE)
-        ui_set_volume_icon(item);
 
     /* if this is the default sink, update status icon acording to volume */
     if(mi->type == MENU_SINK && item == menu_info_item_get_by_name(mi, mi->default_name))

--- a/src/menu_info.c
+++ b/src/menu_info.c
@@ -263,7 +263,7 @@ void menu_info_item_update(menu_info_t* mi, uint32_t index, const char* name,
     }
 
     /* update sink icon */
-    if(mi->type == MENU_SINK)
+    if(mi->type == MENU_SINK || mi->type == MENU_SOURCE)
         ui_set_volume_icon(item);
 
     /* if this is the default sink, update status icon acording to volume */

--- a/src/notify.c
+++ b/src/notify.c
@@ -49,19 +49,23 @@ void notify_show(NotifyNotification* n)
                 error->code);
 }
 
-notify_handle_t notify(const char* msg, const char* body, const char* icon)
+notify_handle_t notify(const char* msg, const char* body, const char* icon, gint value)
 {
     NotifyNotification* n = notify_notification_new(msg, body, icon);
     notify_notification_set_urgency(n, NOTIFY_URGENCY_LOW);
     notify_notification_set_timeout(n, 2000);
+    if(value > -1)
+        notify_notification_set_hint_int32 (n, "value", value);
     notify_show(n);
     return (notify_handle_t) n;
 }
 
-void notify_update(notify_handle_t h, const char* msg, const char* body, const char* icon)
+void notify_update(notify_handle_t h, const char* msg, const char* body, const char* icon, gint value)
 {
     NotifyNotification* n = (NotifyNotification*) h;
     notify_notification_set_timeout(n, 2000); // reset time
+    if(value > -1)
+        notify_notification_set_hint_int32 (n, "value", value);
 
     if(!notify_notification_update(n, msg, body, icon))
         g_error("[notify] invalid arguments passed to notify_update()");

--- a/src/notify.c
+++ b/src/notify.c
@@ -53,7 +53,7 @@ notify_handle_t notify(const char* msg, const char* body, const char* icon, gint
 {
     NotifyNotification* n = notify_notification_new(msg, body, icon);
     notify_notification_set_urgency(n, NOTIFY_URGENCY_LOW);
-    notify_notification_set_timeout(n, 2000);
+    notify_notification_set_timeout(n, 2000); // timeout in ms
     if(value > -1)
         notify_notification_set_hint_int32 (n, "value", value);
     notify_show(n);
@@ -63,7 +63,7 @@ notify_handle_t notify(const char* msg, const char* body, const char* icon, gint
 void notify_update(notify_handle_t h, const char* msg, const char* body, const char* icon, gint value)
 {
     NotifyNotification* n = (NotifyNotification*) h;
-    notify_notification_set_timeout(n, 2000); // reset time
+    notify_notification_set_timeout(n, 2000); // timeout in ms
     if(value > -1)
         notify_notification_set_hint_int32 (n, "value", value);
 

--- a/src/notify.c
+++ b/src/notify.c
@@ -53,6 +53,7 @@ notify_handle_t notify(const char* msg, const char* body, const char* icon)
 {
     NotifyNotification* n = notify_notification_new(msg, body, icon);
     notify_notification_set_urgency(n, NOTIFY_URGENCY_LOW);
+    notify_notification_set_timeout(n, 2000);
     notify_show(n);
     return (notify_handle_t) n;
 }
@@ -60,6 +61,7 @@ notify_handle_t notify(const char* msg, const char* body, const char* icon)
 void notify_update(notify_handle_t h, const char* msg, const char* body, const char* icon)
 {
     NotifyNotification* n = (NotifyNotification*) h;
+    notify_notification_set_timeout(n, 2000); // reset time
 
     if(!notify_notification_update(n, msg, body, icon))
         g_error("[notify] invalid arguments passed to notify_update()");

--- a/src/notify.h
+++ b/src/notify.h
@@ -27,7 +27,7 @@
 typedef void* notify_handle_t;
 
 void notify_initialize();
-notify_handle_t notify(const char* msg, const char* body, const char* icon);
-void notify_update(notify_handle_t h, const char* msg, const char* body, const char* icon);
+notify_handle_t notify(const char* msg, const char* body, const char* icon, gint value);
+void notify_update(notify_handle_t h, const char* msg, const char* body, const char* icon, gint value);
 
 #endif /* PASYSTRAY_NOTIFY_H */

--- a/src/pulseaudio.c
+++ b/src/pulseaudio.c
@@ -364,7 +364,7 @@ void pulseaudio_sink_add(const pa_sink_info* i, int is_last, void* userdata, gbo
     if(is_new && mis->settings.notify != NOTIFY_NEVER)
     {
         gchar* msg = g_strdup_printf("new sink \"%s\"", i->description);
-        notify(msg, i->name, NULL);
+        notify(msg, i->name, NULL, -1);
         g_free(msg);
     }
 
@@ -412,7 +412,7 @@ void pulseaudio_source_add(const pa_source_info* i, int is_last, void* userdata,
     if(is_new && mis->settings.notify != NOTIFY_NEVER)
     {
         gchar* msg = g_strdup_printf("new source \"%s\"", i->description);
-        notify(msg, i->name, NULL);
+        notify(msg, i->name, NULL, -1);
         g_free(msg);
     }
 

--- a/src/pulseaudio_action.c
+++ b/src/pulseaudio_action.c
@@ -183,6 +183,10 @@ void pulseaudio_set_volume_success_cb(pa_context *c, int success, void *userdata
 
     menu_infos_t* mis = mii->menu_info->menu_infos;
 
+    /* update sink icon */
+    if(mii->menu_info->type == MENU_SINK)
+        ui_set_volume_icon(mii);
+
     if(mis->settings.notify != NOTIFY_NEVER)
     {
         pulseaudio_update_volume_notification(mii);

--- a/src/pulseaudio_action.c
+++ b/src/pulseaudio_action.c
@@ -194,10 +194,15 @@ void pulseaudio_update_volume_notification(menu_info_item_t* mii)
     gchar* msg = g_strdup_printf("%s %s",
                 menu_info_type_name(mii->menu_info->type), mii->desc);
 
+    char vol_buf[4];
+    gint volume;
+    pa_volume_snprint(vol_buf, sizeof(vol_buf), mii->volume->values[0]);
+    sscanf(vol_buf, "%d", &volume);
+
     if(!mii->notify)
-        mii->notify = notify(msg, NULL, mii->icon);
+        mii->notify = notify(msg, NULL, mii->icon, volume);
     else
-        notify_update(mii->notify, msg, NULL, mii->icon);
+        notify_update(mii->notify, msg, NULL, mii->icon, volume);
 
     g_free(msg);
 }

--- a/src/pulseaudio_action.c
+++ b/src/pulseaudio_action.c
@@ -184,7 +184,7 @@ void pulseaudio_set_volume_success_cb(pa_context *c, int success, void *userdata
     menu_infos_t* mis = mii->menu_info->menu_infos;
 
     /* update sink icon */
-    if(mii->menu_info->type == MENU_SINK)
+    if(mii->menu_info->type == MENU_SINK || mii->menu_info->type == MENU_SOURCE)
         ui_set_volume_icon(mii);
 
     if(mis->settings.notify != NOTIFY_NEVER)

--- a/src/pulseaudio_action.c
+++ b/src/pulseaudio_action.c
@@ -198,10 +198,7 @@ void pulseaudio_update_volume_notification(menu_info_item_t* mii)
     gchar* msg = g_strdup_printf("%s %s",
                 menu_info_type_name(mii->menu_info->type), mii->desc);
 
-    char vol_buf[4];
-    gint volume;
-    pa_volume_snprint(vol_buf, sizeof(vol_buf), mii->volume->values[0]);
-    sscanf(vol_buf, "%d", &volume);
+    gint volume = (mii->volume->values[0]*100+PA_VOLUME_NORM/2)/PA_VOLUME_NORM;
 
     if(!mii->notify)
         mii->notify = notify(msg, NULL, mii->icon, volume);

--- a/src/ui.c
+++ b/src/ui.c
@@ -71,6 +71,7 @@ void ui_set_volume_icon(menu_info_item_t* mii)
     else
         icon_name = "audio-volume-high";
 
+    g_free(mii->icon);
     mii->icon = g_strdup(icon_name);
 }
 

--- a/src/ui.c
+++ b/src/ui.c
@@ -52,9 +52,9 @@ void ui_load()
     }
 }
 
-void ui_update_systray_icon(menu_info_item_t* mii)
+void ui_set_volume_icon(menu_info_item_t* mii)
 {
-    g_debug("pulseaudio_update_systray_icon(%s)", mii->name);
+    g_debug("pulseaudio_set_volume_icon(%s)", mii->name);
 
     pa_volume_t volume = pa_cvolume_avg(mii->volume);
 
@@ -71,9 +71,17 @@ void ui_update_systray_icon(menu_info_item_t* mii)
     else
         icon_name = "audio-volume-high";
 
-    menu_infos_t* mis = mii->menu_info->menu_infos;
-    systray_impl_set_icon(mis->systray, icon_name);
     mii->icon = g_strdup(icon_name);
+}
+
+void ui_update_systray_icon(menu_info_item_t* mii)
+{
+    g_debug("pulseaudio_update_systray_icon(%s)", mii->name);
+
+    ui_set_volume_icon(mii);
+
+    menu_infos_t* mis = mii->menu_info->menu_infos;
+    systray_impl_set_icon(mis->systray, mii->icon);
 }
 
 GtkDialog* ui_aboutdialog()

--- a/src/ui.c
+++ b/src/ui.c
@@ -73,6 +73,7 @@ void ui_update_systray_icon(menu_info_item_t* mii)
 
     menu_infos_t* mis = mii->menu_info->menu_infos;
     systray_impl_set_icon(mis->systray, icon_name);
+    mii->icon = g_strdup(icon_name);
 }
 
 GtkDialog* ui_aboutdialog()


### PR DESCRIPTION
This PR contains the initial patch from the always-notify branch and fixes it.
Further the notifications now use the volume gauge like xfce4-volumed and some others do.
They now also show the icon used in tray as notification icon.
Since the notifications showed for ~5 seconds the timeout was lowered to 2s.