### PR TITLE
for-upstream/sync-sink

### DIFF
--- a/man/pasystray.1
+++ b/man/pasystray.1
@@ -108,6 +108,12 @@ Enable notifications for all changes in pulsaudio.
 .TP
 .B \-\-include-monitors
 Show monitor sources.
+.TP
+.B \-s, \-\-sync-default
+Sync default sink on input stream sink change.
+.TP
+.B \-t, \-\-sync-streams
+Sync sink of all streams on default sink change.
 .SH SEE ALSO
 .BR pulseaudio (1),
 .BR pactl (1).

--- a/src/menu_info.c
+++ b/src/menu_info.c
@@ -569,6 +569,8 @@ void menu_info_subitem_clicked(GtkWidget* item, GdkEventButton* event,
             (event->state & GDK_MOD1_MASK) ? "[alt]" : "",
             event->button);
 
+    menu_infos_t* mis = mii->menu_info->menu_infos;
+
     switch(mii->menu_info->type)
     {
         case MENU_SERVER:
@@ -578,6 +580,8 @@ void menu_info_subitem_clicked(GtkWidget* item, GdkEventButton* event,
             break;
         case MENU_SINK:
             pulseaudio_move_input_to_sink(mii->menu_info->parent, mii);
+            if(mis->settings.sync_default)
+                pulseaudio_set_default(mii);
             break;
         case MENU_SOURCE:
             pulseaudio_move_output_to_source(mii->menu_info->parent, mii);

--- a/src/menu_info.c
+++ b/src/menu_info.c
@@ -496,6 +496,8 @@ void menu_info_item_clicked(GtkWidget* item, GdkEventButton* event,
             (event->state & GDK_MOD1_MASK) ? "[alt]" : "",
             event->button);
 
+    menu_infos_t* mis = mii->menu_info->menu_infos;
+
     switch(event->button)
     {
         case 1:
@@ -506,6 +508,8 @@ void menu_info_item_clicked(GtkWidget* item, GdkEventButton* event,
             /* on left-click, set device as default */
             else
                 pulseaudio_set_default(mii);
+                if(mis->settings.sync_streams)
+                    pulseaudio_move_all_inputs_to_sink(mii);
             break;
         /* on middle-click, toggle mute device/stream */
         case 2:

--- a/src/menu_info.h
+++ b/src/menu_info.h
@@ -66,6 +66,7 @@ struct settings_t_ {
     int volume_inc;
     notify_t notify;
     gboolean monitors;
+    gboolean sync_default;
 };
 typedef struct settings_t_ settings_t;
 

--- a/src/menu_info.h
+++ b/src/menu_info.h
@@ -67,6 +67,7 @@ struct settings_t_ {
     notify_t notify;
     gboolean monitors;
     gboolean sync_default;
+    gboolean sync_streams;
 };
 typedef struct settings_t_ settings_t;
 

--- a/src/options.c
+++ b/src/options.c
@@ -32,6 +32,7 @@ static int volume_inc = 1;
 static gboolean no_notify = FALSE;
 static gboolean always_notify = FALSE;
 static gboolean monitors = FALSE;
+static gboolean sync_default = FALSE;
 
 static GOptionEntry entries[] =
 {
@@ -44,6 +45,7 @@ static GOptionEntry entries[] =
     { "always-notify", 'a', 0, G_OPTION_ARG_NONE, &always_notify,
         "enable notifications for all changes in pulsaudio", NULL },
     { "include-monitors", 'n', 0, G_OPTION_ARG_NONE, &monitors, "include monitor sources", NULL },
+    { "sync-default", 's', 0, G_OPTION_ARG_NONE, &sync_default, "sync default sink on input stream sink change", NULL },
     { .long_name = NULL }
 };
 
@@ -88,4 +90,6 @@ void parse_options(settings_t* settings)
     }
 
     settings->monitors = monitors;
+
+    settings->sync_default = sync_default;
 }

--- a/src/options.c
+++ b/src/options.c
@@ -33,6 +33,7 @@ static gboolean no_notify = FALSE;
 static gboolean always_notify = FALSE;
 static gboolean monitors = FALSE;
 static gboolean sync_default = FALSE;
+static gboolean sync_streams = FALSE;
 
 static GOptionEntry entries[] =
 {
@@ -46,6 +47,7 @@ static GOptionEntry entries[] =
         "enable notifications for all changes in pulsaudio", NULL },
     { "include-monitors", 'n', 0, G_OPTION_ARG_NONE, &monitors, "include monitor sources", NULL },
     { "sync-default", 's', 0, G_OPTION_ARG_NONE, &sync_default, "sync default sink on input stream sink change", NULL },
+    { "sync-streams", 't', 0, G_OPTION_ARG_NONE, &sync_streams, "sync sink of all streams on default sink change", NULL },
     { .long_name = NULL }
 };
 
@@ -92,4 +94,5 @@ void parse_options(settings_t* settings)
     settings->monitors = monitors;
 
     settings->sync_default = sync_default;
+    settings->sync_streams = sync_streams;
 }

--- a/src/pulseaudio_action.h
+++ b/src/pulseaudio_action.h
@@ -33,6 +33,9 @@ void pulseaudio_move_output_to_source(menu_info_item_t* output, menu_info_item_t
 void pulseaudio_move_all(menu_info_item_t* mii);
 void pulseaudio_move_success_cb(pa_context *c, int success, void *userdata);
 
+void pulseaudio_move_all_inputs_to_sink(menu_info_item_t* sink);
+void pulseaudio_move_all_inputs_to_sink_cb(pa_context* c, const pa_sink_input_info* i, int is_last, void* userdata);
+
 void pulseaudio_rename(menu_info_item_t* mii, const char* name);
 void pulseaudio_rename_success_cb(pa_context *c, int success, void *userdata);
 


### PR DESCRIPTION
This PR adds two options for syncing sinks.
1. When selecting the default sink, set all input streams to that sink. This is what is requested in #59.
2. Sync the default sink when changing a sink input / stream. Simple the other way round. This is very useful when you control your volume with keyboard shortcuts since you would need to manually set the default sink to control the stream you are listening to.