### PR TITLE
Fix compilation without notifications

### DIFF
--- a/src/notify.c
+++ b/src/notify.c
@@ -26,8 +26,8 @@
 #include "notify.h"
 
 void notify_initialize(){}
-notify_handle_t notify(const char* msg, const char* body, const char* icon){ return 0; }
-void notify_update(notify_handle_t h, const char* msg, const char* body, const char* icon){}
+notify_handle_t notify(const char* msg, const char* body, const char* icon, gint value){ return 0; }
+void notify_update(notify_handle_t h, const char* msg, const char* body, const char* icon, gint value){}
 
 #else
 

--- a/src/notify.h
+++ b/src/notify.h
@@ -24,6 +24,10 @@
 
 #include "config.h"
 
+#ifndef HAVE_NOTIFY
+typedef int gint;
+#endif
+
 typedef void* notify_handle_t;
 
 void notify_initialize();


### PR DESCRIPTION
These changes fix two errors preventing pasystray from being compiled when notifications are disabled or when libnotify headers are not installed.