### PR TITLE
Granular notification options

### DIFF
--- a/src/menu_info.c
+++ b/src/menu_info.c
@@ -285,8 +285,8 @@ void menu_info_item_update(menu_info_t* mi, uint32_t index, const char* name,
     if(mi->type == MENU_SINK && item == menu_info_item_get_by_name(mi, mi->default_name))
         ui_update_systray_icon(item);
 
-    if(notify && mis->settings.notify == NOTIFY_ALWAYS)
-        pulseaudio_update_volume_notification(item);
+    if(notify)
+        pulseaudio_process_update_volume_notification(item);
 }
 
 void menu_info_item_add(menu_info_t* mi, uint32_t index, const char* name,

--- a/src/menu_info.h
+++ b/src/menu_info.h
@@ -66,6 +66,15 @@ struct settings_t_ {
     int volume_inc;
     notify_t notify;
     gboolean monitors;
+    // Granular notification options below
+    gboolean n_new;
+    gboolean n_sink_all;
+    gboolean n_sink_default;
+    gboolean n_source_all;
+    gboolean n_source_default;
+    gboolean n_stream_all;
+    gboolean n_stream_output;
+    gboolean n_stream_input;
 };
 typedef struct settings_t_ settings_t;
 

--- a/src/menu_info.h
+++ b/src/menu_info.h
@@ -55,18 +55,11 @@ struct menu_info_t_ {
     char* default_name;
 };
 
-typedef enum {
-    NOTIFY_NEVER,
-    NOTIFY_DEFAULT,
-    NOTIFY_ALWAYS,
-} notify_t;
-
 struct settings_t_ {
     int volume_max;
     int volume_inc;
-    notify_t notify;
     gboolean monitors;
-    // Granular notification options below
+    // Notification options below
     gboolean n_new;
     gboolean n_sink_all;
     gboolean n_sink_default;
@@ -75,6 +68,7 @@ struct settings_t_ {
     gboolean n_stream_all;
     gboolean n_stream_output;
     gboolean n_stream_input;
+    gboolean n_systray_action;
 };
 typedef struct settings_t_ settings_t;
 

--- a/src/options.c
+++ b/src/options.c
@@ -83,13 +83,14 @@ void parse_options(settings_t* settings)
     settings->notify = NOTIFY_DEFAULT;
     if(no_notify)
     {
-        settings->notify = NOTIFY_NEVER;
+        settings->notify = NOTIFY_NEVER; // TODO: Translate this to granular notification setting format
     }
     if(always_notify)
     {
-        settings->notify = NOTIFY_ALWAYS;
+        settings->notify = NOTIFY_ALWAYS; // TODO: Translate this to granular notification setting format
     }
 
+    settings->n_new = FALSE;
     if(notify_mode)
     {
         /*  PLANNED MODES
@@ -114,6 +115,10 @@ void parse_options(settings_t* settings)
             else if(g_str_equal(notify_mode[i], "none"))
             {
                 // TODO: Implement
+            }
+            else if(g_str_equal(notify_mode[i], "new"))
+            {
+                settings->n_new = TRUE;
             }
             else if(g_str_equal(notify_mode[i], "sink_all"))
             {

--- a/src/options.c
+++ b/src/options.c
@@ -90,7 +90,14 @@ void parse_options(settings_t* settings)
         settings->notify = NOTIFY_ALWAYS; // TODO: Translate this to granular notification setting format
     }
 
-    settings->n_new = FALSE;
+    // Set some default values close to previous behavior
+    settings->n_new = TRUE;
+    settings->n_sink_all = FALSE;
+    settings->n_sink_default = FALSE;
+    settings->n_source_all = FALSE;
+    settings->n_source_default = FALSE;
+    settings->n_stream_output = FALSE;
+    settings->n_stream_input = FALSE;
     if(notify_mode)
     {
         /*  PLANNED MODES
@@ -110,11 +117,24 @@ void parse_options(settings_t* settings)
         for (int i = 0; notify_mode[i]; i++) {
             if(!g_strcmp0(notify_mode[i], "all"))
             {
-                // TODO: Implement
+                settings->n_new = TRUE;
+                settings->n_sink_all = TRUE;
+                settings->n_sink_default = TRUE;
+                settings->n_source_all = TRUE;
+                settings->n_source_default = TRUE;
+                settings->n_stream_output = TRUE;
+                settings->n_stream_input = TRUE;
+
             }
             else if(g_str_equal(notify_mode[i], "none"))
             {
-                // TODO: Implement
+                settings->n_new = FALSE;
+                settings->n_sink_all = FALSE;
+                settings->n_sink_default = FALSE;
+                settings->n_source_all = FALSE;
+                settings->n_source_default = FALSE;
+                settings->n_stream_output = FALSE;
+                settings->n_stream_input = FALSE;
             }
             else if(g_str_equal(notify_mode[i], "new"))
             {
@@ -126,7 +146,7 @@ void parse_options(settings_t* settings)
             }
             else if(g_str_equal(notify_mode[i], "sink_default"))
             {
-                settings->n_sink_default = TRUE; 
+                settings->n_sink_default = TRUE;
             }
             else if(g_str_equal(notify_mode[i], "source_all"))
             {

--- a/src/options.c
+++ b/src/options.c
@@ -32,7 +32,6 @@ static int volume_inc = 1;
 static gboolean no_notify = FALSE;
 static gboolean always_notify = FALSE;
 static gboolean monitors = FALSE;
-// static gchar notify_mode[10][20];
 static gchar **notify_mode;
 
 static GOptionEntry entries[] =
@@ -80,16 +79,6 @@ void parse_options(settings_t* settings)
         settings->volume_inc = volume_inc;
     }
 
-    settings->notify = NOTIFY_DEFAULT;
-    if(no_notify)
-    {
-        settings->notify = NOTIFY_NEVER; // TODO: Translate this to granular notification setting format
-    }
-    if(always_notify)
-    {
-        settings->notify = NOTIFY_ALWAYS; // TODO: Translate this to granular notification setting format
-    }
-
     // Set some default values close to previous behavior
     settings->n_new = TRUE;
     settings->n_sink_all = FALSE;
@@ -98,21 +87,23 @@ void parse_options(settings_t* settings)
     settings->n_source_default = FALSE;
     settings->n_stream_output = FALSE;
     settings->n_stream_input = FALSE;
+    settings->n_systray_action = TRUE;
     if(notify_mode)
     {
         /*  PLANNED MODES
-            all             notify for all detected changes
-            none            notify none
-            new             notify when new sinks/sources are detected
-            sink_all        notify for changes to all sinks
-            sink_default    notify for changes to the default sink
-            source_all
-            source_default  notify for the default source
-            stream_all      notify for all streams   
-            stream_output   notify for output (playback) streams
-            stream_input    notify for input (recording) streams
+            all                     notify for all detected changes
+            none                    notify none
+            new                     notify when new sinks/sources are detected
+            sink_all                notify for changes to all sinks
+            sink_default            notify for changes to the default sink
+            source_all              notify for changes to all sources
+            source_default          notify for changes to the default source
+            stream_all              notify for all streams   
+            stream_output           notify for output (playback) streams
+            stream_input            notify for input (recording) streams
+            systray_action          notify for changes made through pasystray
 
-            help            SPECIAL: List possible modes and exit
+            help                    SPECIAL: List possible modes and exit
         */
         for (int i = 0; notify_mode[i]; i++) {
             if(!g_strcmp0(notify_mode[i], "all"))
@@ -124,7 +115,7 @@ void parse_options(settings_t* settings)
                 settings->n_source_default = TRUE;
                 settings->n_stream_output = TRUE;
                 settings->n_stream_input = TRUE;
-
+                settings->n_systray_action = TRUE;
             }
             else if(g_str_equal(notify_mode[i], "none"))
             {
@@ -135,6 +126,7 @@ void parse_options(settings_t* settings)
                 settings->n_source_default = FALSE;
                 settings->n_stream_output = FALSE;
                 settings->n_stream_input = FALSE;
+                settings->n_systray_action = FALSE;
             }
             else if(g_str_equal(notify_mode[i], "new"))
             {
@@ -178,6 +170,29 @@ void parse_options(settings_t* settings)
                 // TODO: Implement
             }
         }
+    }
+
+    if(no_notify)
+    {
+        settings->n_new = FALSE;
+        settings->n_sink_all = FALSE;
+        settings->n_sink_default = FALSE;
+        settings->n_source_all = FALSE;
+        settings->n_source_default = FALSE;
+        settings->n_stream_output = FALSE;
+        settings->n_stream_input = FALSE;
+        settings->n_systray_action = FALSE;
+    }
+    if(always_notify)
+    {
+        settings->n_new = TRUE;
+        settings->n_sink_all = TRUE;
+        settings->n_sink_default = TRUE;
+        settings->n_source_all = TRUE;
+        settings->n_source_default = TRUE;
+        settings->n_stream_output = TRUE;
+        settings->n_stream_input = TRUE;
+        settings->n_systray_action = TRUE;
     }
 
     settings->monitors = monitors;

--- a/src/options.c
+++ b/src/options.c
@@ -111,19 +111,47 @@ void parse_options(settings_t* settings)
             {
                 // TODO: Implement
             }
-            else if(!g_strcmp0(notify_mode[i], "none"))
+            else if(g_str_equal(notify_mode[i], "none"))
             {
                 // TODO: Implement
             }
-            else if(!g_strcmp0(notify_mode[i], "sink_all"))
+            else if(g_str_equal(notify_mode[i], "sink_all"))
             {
                 settings->n_sink_all = TRUE;
             }
-            else if(!g_strcmp0(notify_mode[i], "sink_default"))
+            else if(g_str_equal(notify_mode[i], "sink_default"))
             {
                 settings->n_sink_default = TRUE; 
             }
-
+            else if(g_str_equal(notify_mode[i], "source_all"))
+            {
+                settings->n_source_all = TRUE;
+            }
+            else if(g_str_equal(notify_mode[i], "source_default"))
+            {
+                settings->n_source_default = TRUE;
+            }
+            else if(g_str_equal(notify_mode[i], "stream_all"))
+            {
+                settings->n_stream_output = TRUE;
+                settings->n_stream_input = TRUE;
+            }
+            else if(g_str_equal(notify_mode[i], "stream_output"))
+            {
+                settings->n_stream_output = TRUE;
+            }
+            else if(g_str_equal(notify_mode[i], "stream_input"))
+            {
+                settings->n_stream_input = TRUE;
+            }
+            else if(g_str_equal(notify_mode[i], "help"))
+            {
+                // TODO: Implement
+            }
+            else
+            {
+                // TODO: Implement
+            }
         }
     }
 

--- a/src/options.c
+++ b/src/options.c
@@ -32,6 +32,8 @@ static int volume_inc = 1;
 static gboolean no_notify = FALSE;
 static gboolean always_notify = FALSE;
 static gboolean monitors = FALSE;
+// static gchar notify_mode[10][20];
+static gchar **notify_mode;
 
 static GOptionEntry entries[] =
 {
@@ -44,6 +46,7 @@ static GOptionEntry entries[] =
     { "always-notify", 'a', 0, G_OPTION_ARG_NONE, &always_notify,
         "enable notifications for all changes in pulsaudio", NULL },
     { "include-monitors", 'n', 0, G_OPTION_ARG_NONE, &monitors, "include monitor sources", NULL },
+    { "notify", 'N', 0, G_OPTION_ARG_STRING_ARRAY, &notify_mode, "notify mode", "NOTIFICATION TYPE" },
     { .long_name = NULL }
 };
 
@@ -85,6 +88,43 @@ void parse_options(settings_t* settings)
     if(always_notify)
     {
         settings->notify = NOTIFY_ALWAYS;
+    }
+
+    if(notify_mode)
+    {
+        /*  PLANNED MODES
+            all             notify for all detected changes
+            none            notify none
+            new             notify when new sinks/sources are detected
+            sink_all        notify for changes to all sinks
+            sink_default    notify for changes to the default sink
+            source_all
+            source_default  notify for the default source
+            stream_all      notify for all streams   
+            stream_output   notify for output (playback) streams
+            stream_input    notify for input (recording) streams
+
+            help            SPECIAL: List possible modes and exit
+        */
+        for (int i = 0; notify_mode[i]; i++) {
+            if(!g_strcmp0(notify_mode[i], "all"))
+            {
+                // TODO: Implement
+            }
+            else if(!g_strcmp0(notify_mode[i], "none"))
+            {
+                // TODO: Implement
+            }
+            else if(!g_strcmp0(notify_mode[i], "sink_all"))
+            {
+                settings->n_sink_all = TRUE;
+            }
+            else if(!g_strcmp0(notify_mode[i], "sink_default"))
+            {
+                settings->n_sink_default = TRUE; 
+            }
+
+        }
     }
 
     settings->monitors = monitors;

--- a/src/options.c
+++ b/src/options.c
@@ -45,7 +45,8 @@ static GOptionEntry entries[] =
     { "always-notify", 'a', 0, G_OPTION_ARG_NONE, &always_notify,
         "enable notifications for all changes in pulsaudio", NULL },
     { "include-monitors", 'n', 0, G_OPTION_ARG_NONE, &monitors, "include monitor sources", NULL },
-    { "notify", 'N', 0, G_OPTION_ARG_STRING_ARRAY, &notify_mode, "notify mode", "NOTIFICATION TYPE" },
+    { "notify", 'N', 0, G_OPTION_ARG_STRING_ARRAY, &notify_mode,
+        "Set notification options, use --notify=help for a list of valid options", "OPTION" },
     { .long_name = NULL }
 };
 
@@ -90,21 +91,6 @@ void parse_options(settings_t* settings)
     settings->n_systray_action = TRUE;
     if(notify_mode)
     {
-        /*  PLANNED MODES
-            all                     notify for all detected changes
-            none                    notify none
-            new                     notify when new sinks/sources are detected
-            sink_all                notify for changes to all sinks
-            sink_default            notify for changes to the default sink
-            source_all              notify for changes to all sources
-            source_default          notify for changes to the default source
-            stream_all              notify for all streams   
-            stream_output           notify for output (playback) streams
-            stream_input            notify for input (recording) streams
-            systray_action          notify for changes made through pasystray
-
-            help                    SPECIAL: List possible modes and exit
-        */
         for (int i = 0; notify_mode[i]; i++) {
             if(!g_strcmp0(notify_mode[i], "all"))
             {
@@ -163,11 +149,28 @@ void parse_options(settings_t* settings)
             }
             else if(g_str_equal(notify_mode[i], "help"))
             {
-                // TODO: Implement
+                gchar *help_text=(
+                    "Notification options:\n"
+                    "  all                     Notify for all detected changes\n"
+                    "  none                    Never notify, except for options set after this one\n"
+                    "  new                     Notify when new sinks/sources are added\n"
+                    "  sink_all                Notify for changes to all sinks\n"
+                    "  sink_default            Notify for changes to the default sink\n"
+                    "  source_all              Notify for changes to all sources\n"
+                    "  source_default          Notify for changes to the default source\n"
+                    "  stream_all              Notify for all streams\n"
+                    "  stream_output           Notify for output (playback) streams\n"
+                    "  stream_input            Notify for input (recording) streams\n"
+                    "  systray_action          Notify for changes made through pasystray\n"
+                    "  help                    List possible options and exit\n"
+                );
+
+                g_print("%s",help_text);
+                exit(0);
             }
             else
             {
-                // TODO: Implement
+                g_print("Warning: Invalid notification option \"%s\". Run 'pasystray --notify=help' for a list of valid options.\n", notify_mode[i]);
             }
         }
     }

--- a/src/pulseaudio.c
+++ b/src/pulseaudio.c
@@ -378,7 +378,7 @@ void pulseaudio_sink_add(const pa_sink_info* i, int is_last, void* userdata, gbo
     menu_info_t* mi = userdata;
     menu_infos_t* mis = mi->menu_infos;
 
-    if(is_new && mis->settings.notify != NOTIFY_NEVER)
+    if(is_new && mis->settings.n_new)
     {
         gchar* msg = g_strdup_printf("new sink \"%s\"", i->description);
         notify(msg, i->name, NULL, -1);
@@ -426,7 +426,7 @@ void pulseaudio_source_add(const pa_source_info* i, int is_last, void* userdata,
     if(!mis->settings.monitors && class && g_str_equal(class, "monitor"))
         return;
 
-    if(is_new && mis->settings.notify != NOTIFY_NEVER)
+    if(is_new && mis->settings.n_new)
     {
         gchar* msg = g_strdup_printf("new source \"%s\"", i->description);
         notify(msg, i->name, NULL, -1);

--- a/src/pulseaudio_action.c
+++ b/src/pulseaudio_action.c
@@ -217,7 +217,7 @@ void pulseaudio_set_volume_success_cb(pa_context *c, int success, void *userdata
     if(mii->menu_info->type == MENU_SINK || mii->menu_info->type == MENU_SOURCE)
         ui_set_volume_icon(mii);
 
-    if(mis->settings.notify != NOTIFY_NEVER)
+    if(mis->settings.n_systray_action)
     {
         pulseaudio_update_volume_notification(mii);
     }

--- a/src/pulseaudio_action.c
+++ b/src/pulseaudio_action.c
@@ -238,12 +238,14 @@ void pulseaudio_process_update_volume_notification(menu_info_item_t* mii)
         case MENU_SINK:
             if(mis->settings.n_sink_all)
                 notify = TRUE;
-            else if(mis->settings.n_sink_default && mii == menu_info_item_get_by_name(mi, mi->default_name))
-            {
+            else if(mis->settings.n_sink_default && g_str_equal(mii->name, mi->default_name))
                 notify = TRUE;
-            }
             break;
         case MENU_SOURCE:
+            if(mis->settings.n_source_all)
+                notify = TRUE;
+            else if(mis->settings.n_source_default && g_str_equal(mii->name, mi->default_name))
+                notify = TRUE;
             break;
         case MENU_INPUT:
 

--- a/src/pulseaudio_action.c
+++ b/src/pulseaudio_action.c
@@ -223,6 +223,42 @@ void pulseaudio_set_volume_success_cb(pa_context *c, int success, void *userdata
     }
 }
 
+void pulseaudio_process_update_volume_notification(menu_info_item_t* mii)
+{
+    menu_infos_t* mis = mii->menu_info->menu_infos;
+    menu_info_t* mi = mii->menu_info;
+    gboolean notify = FALSE;
+    // Check for type
+    switch(mi->type)
+    {
+        case MENU_SERVER:
+        case MENU_MODULE:
+            /* nothing to do here */
+            break;
+        case MENU_SINK:
+            if(mis->settings.n_sink_all)
+                notify = TRUE;
+            else if(mis->settings.n_sink_default && mii == menu_info_item_get_by_name(mi, mi->default_name))
+            {
+                notify = TRUE;
+            }
+            break;
+        case MENU_SOURCE:
+            break;
+        case MENU_INPUT:
+
+            break;
+        case MENU_OUTPUT:
+            break;
+    }
+
+
+    if(notify)
+    {
+        pulseaudio_update_volume_notification(mii);
+    }
+}
+
 void pulseaudio_update_volume_notification(menu_info_item_t* mii)
 {
     gchar* label = menu_info_item_label(mii);

--- a/src/pulseaudio_action.h
+++ b/src/pulseaudio_action.h
@@ -38,6 +38,7 @@ void pulseaudio_rename_success_cb(pa_context *c, int success, void *userdata);
 
 void pulseaudio_volume(menu_info_item_t* mii, int inc);
 void pulseaudio_set_volume_success_cb(pa_context *c, int success, void *userdata);
+void pulseaudio_process_update_volume_notification(menu_info_item_t* mii);
 void pulseaudio_update_volume_notification(menu_info_item_t* mii);
 
 void pulseaudio_toggle_mute(menu_info_item_t* mii);


### PR DESCRIPTION
This adds more configurability for notifications sent by pasystray.

Notification options are set by setting a series of `--notify=OPTION` options, with the following options currently available:
 * `all`
 * `none`
     - Notifications set after this one will still send.
 * `new`
     - This notifies for newly added sinks & sources.
 * `sink_all`
 * `sink_default`
 * `source_all`
 * `source_default`
 * `stream_all`
 * `stream_output`
 * `stream_input`
 * `systray_action`
     - This notifies for all changes made via interaction with pasystray.
     - This option was included mainly to allow default notification behavior
       to remain consistent with previous versions.