### PR TITLE
Fix: Recognize the option -N systray_action

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -163,6 +163,10 @@ void parse_options(settings_t* settings)
             {
                 settings->n_stream_input = TRUE;
             }
+            else if(g_str_equal(notify_mode[i], "systray_action"))
+            {
+                settings->n_systray_action = TRUE;
+            }
             else if(g_str_equal(notify_mode[i], "help"))
             {
                 gchar *help_text=(


### PR DESCRIPTION
`-N help` lists an the option `systray_action`, which is implemented correctly for the none/default notification sets, but not recognized as a command line parameter.