### PR TITLE
Foolproof

### DIFF
--- a/man/pasystray.1
+++ b/man/pasystray.1
@@ -4,7 +4,7 @@
 .\" First parameter, NAME, should be all caps
 .\" Second parameter, SECTION, should be 1-8, maybe w/ subsection
 .\" other parameters are allowed: see man(7), man(1)
-.TH PASYSTRAY 1 "June 14, 2018"
+.TH PASYSTRAY 1 "June 15, 2018"
 .\" Please adjust this date whenever revising the manpage.
 .\"
 .\" Some roff macros, for reference:
@@ -102,6 +102,9 @@ Set the volume increment.
 .TP
 .B \-t, \-\-no-icon-tooltip
 Disable the status icon tooltip for the connected state.
+.TP
+.B \-f, \-\-foolproof
+Disable the 'Quit' menu entry.
 .TP
 .B \-n, \-\-no-notify
 Disable all notifications.

--- a/src/menu_info.h
+++ b/src/menu_info.h
@@ -59,6 +59,7 @@ struct settings_t_ {
     int volume_max;
     int volume_inc;
     gboolean icon_tooltip;
+    gboolean foolproof;
     gboolean monitors;
     // Notification options below
     gboolean n_new;

--- a/src/options.c
+++ b/src/options.c
@@ -30,6 +30,7 @@ static gboolean debug = FALSE;
 static int volume_max = 0;
 static int volume_inc = 1;
 static gboolean icon_tooltip = TRUE;
+static gboolean foolproof = FALSE;
 static gboolean no_notify = FALSE;
 static gboolean always_notify = FALSE;
 static gboolean monitors = FALSE;
@@ -43,6 +44,7 @@ static GOptionEntry entries[] =
     { "volume-inc", 'i', 0, G_OPTION_ARG_INT, &volume_inc, "Volume increment", "N" },
     { "no-icon-tooltip", 't', G_OPTION_FLAG_REVERSE, G_OPTION_ARG_NONE,
         &icon_tooltip, "Disable the status icon tooltip for the connected state", NULL },
+    { "foolproof", 'f', 0, G_OPTION_ARG_NONE, &foolproof, "Disable the 'Quit' menu entry", NULL },
     { "no-notify", 'n', 0, G_OPTION_ARG_NONE, &no_notify,
         "Deprecated, use --notify=none instead", NULL },
     { "always-notify", 'a', 0, G_OPTION_ARG_NONE, &always_notify,
@@ -121,6 +123,8 @@ void parse_options(settings_t* settings)
     }
 
     settings->icon_tooltip = icon_tooltip;
+
+    settings->foolproof = foolproof;
 
     notify_default(settings);
 

--- a/src/systray.c
+++ b/src/systray.c
@@ -72,7 +72,8 @@ void systray_menu_create(menu_infos_t* mis)
         G_CALLBACK(pulseaudio_terminate));
 
     systray_menu_add_action(mis->menu, "About", "help-about", G_CALLBACK(systray_about_dialog));
-    systray_menu_add_action(mis->menu, "Quit", "application-exit", G_CALLBACK(quit));
+    if(!mis->settings.foolproof)
+        systray_menu_add_action(mis->menu, "Quit", "application-exit", G_CALLBACK(quit));
 }
 
 void systray_rootmenu_add_submenu(menu_infos_t* mis, menu_type_t type, const char* name, const char* icon)


### PR DESCRIPTION
Provide a new option and setting (`foolproof`) to disable the 'Quit'
menu entry.