### PR TITLE
Fix null unref in pulseaudio_terminate

### DIFF
--- a/src/pulseaudio_action.c
+++ b/src/pulseaudio_action.c
@@ -365,5 +365,8 @@ void pulseaudio_module_unload_success_cb(pa_context *c, int success, void *userd
 
 void pulseaudio_terminate(void)
 {
-    pa_operation_unref(pa_context_exit_daemon(context, NULL, NULL));
+    pa_operation* exit_op = pa_context_exit_daemon(context, NULL, NULL);
+    if (exit_op) {
+        pa_operation_unref(exit_op);
+    }
 }


### PR DESCRIPTION
Clicking "Terminate server" consecutively results in:
`Assertion 'o' failed at pulse/operation.c:67, function pa_operation_unref(). Aborting`

This commit prevents NULL to be passed to pa_operation_unref and program termination.