### PR TITLE
Fix menu item clicks not triggering action on Ubuntu

### DIFF
--- a/src/menu_info.h
+++ b/src/menu_info.h
@@ -127,10 +127,12 @@ menu_info_item_t* menu_info_item_get(menu_info_t* mi, uint32_t index);
 menu_info_item_t* menu_info_item_get_by_name(menu_info_t* mi, const char* name);
 menu_info_item_t* menu_info_item_get_by_desc(menu_info_t* mi, const char* desc);
 
+void menu_info_item_activated(GtkWidget* item, menu_info_item_t* mii);
 void menu_info_item_clicked(GtkWidget* item, GdkEventButton* event,
         menu_info_item_t* mii);
 void menu_info_item_scrolled(GtkWidget* item, GdkEventScroll* event,
         menu_info_item_t* mii);
+void menu_info_subitem_activated(GtkWidget* item, menu_info_item_t* mii);
 void menu_info_subitem_clicked(GtkWidget* item, GdkEventButton* event,
         menu_info_item_t* mii);
 


### PR DESCRIPTION
The `pasystray`-version this pull request is based on seems to have issues regarding the reception of click events on Ubuntu machines with AppIndicator. The new `activate` handlers substitute the current click handlers for default left click events, since `activate` events do trigger.

Tested on a Linux machine with Ubuntu 18.04.