### PR TITLE
Travis-ci: added support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,9 @@ addons:
       - libnotify-dev
       - libappindicator3-dev
 language: c
+arch:
+  - AMD64
+  - ppc64le
 script: ./.travis.sh
 env:
   - CFLAGS=--std=c99


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.