### PR TITLE
Use volume max from all channels instead of first one's

### DIFF
--- a/src/pulseaudio_action.c
+++ b/src/pulseaudio_action.c
@@ -276,7 +276,7 @@ void pulseaudio_update_volume_notification(menu_info_item_t* mii)
                 menu_info_type_name(mii->menu_info->type), label);
     g_free(label);
 
-    gint volume = (mii->volume->values[0]*100+PA_VOLUME_NORM/2)/PA_VOLUME_NORM;
+    gint volume = (pa_cvolume_max(mii->volume)*100+PA_VOLUME_NORM/2)/PA_VOLUME_NORM;
 
     int volume_max = mii->menu_info->menu_infos->settings.volume_max;
     gint value = (volume_max > 0) ? volume * 100 / volume_max : volume;


### PR DESCRIPTION
This change uses the maximum volume of all channels as the volume value for the notification.

My use case is that I often change the balance of my devices, and I do so by setting different volume for left and right channels. Pasystray does an amazing job of keeping the volumes of the channels relative to each other on volume change, but when the balance is set to the right (first channel lower than the second one), once the max is reached, the notification stops at the
first channel volume (i.e. not the max). The expected behavior happens when the balance is set to the left.

Given that pasystray will stop increasing the volume once one of the channels arrived to max, it seems logical to use the maximum value of all channels as the volume value for the notification.
