### PR TITLE
Use volume max for icon instead of avg

### DIFF
--- a/src/ui.c
+++ b/src/ui.c
@@ -92,7 +92,7 @@ void ui_set_volume_icon(menu_info_item_t* mii)
 {
     g_debug("pulseaudio_set_volume_icon(%s)", mii->name);
 
-    pa_volume_t volume = pa_cvolume_avg(mii->volume);
+    pa_volume_t volume = pa_cvolume_max(mii->volume);
 
     g_debug("volume:%u%s", volume, mii->mute ? " muted" : "");
 


### PR DESCRIPTION
Following up #141, given that pasystray will stop increasing the volume once one of the channels arrived to max, it seems logical to index the volume icon on the maximum value of all channels.

This might be a controversial change and I am open to discussion, but IMO this is usually what people expect from this icon.

Indeed, with avg, if one of the channels is set a lot higher than the other ones, the icon could show a low volume while the maximum is reached.
When using channels volume as a balance setting for instance this is misguiding as one could think there is some volume left to increase when in fact it is set to the maximum.
