### PR TITLE
[upd] Add a zero-volume indication

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -19,7 +19,7 @@
 
 AC_PREREQ([2.68])
 
-AC_INIT([pasystray], [0.8.0], [christoph.gysin@gmail.com], [pasystray],
+AC_INIT([pasystray], [0.9.0], [christoph.gysin@gmail.com], [pasystray],
         [http://github.com/christophgysin/pasystray])
 AC_CONFIG_SRCDIR([src/pasystray.c])
 AC_CONFIG_HEADERS([src/config.h])

--- a/src/ui.c
+++ b/src/ui.c
@@ -159,7 +159,6 @@ GtkDialog* ui_errordialog(const gchar* title, const gchar* message)
 static const gchar* ui_find_icon_name(GtkIconTheme* theme, icon_set_t icons, icon_idx_t idx)
 {
     while (idx < ICON_IDX_COUNT) {
-        g_debug(g_strdup_printf("Index: %d", idx));
         const gchar* name = icons[idx];
         const gchar* s = g_strdup_printf("%s-symbolic", name);
         if(gtk_icon_theme_has_icon(theme, s))
@@ -169,7 +168,6 @@ static const gchar* ui_find_icon_name(GtkIconTheme* theme, icon_set_t icons, ico
             return name;
         idx++;
     }
-    g_debug("NULL");
     return NULL;
 }
 
@@ -182,11 +180,13 @@ static void ui_load_icons(void) {
                 if(ui_icon_names[mt][i] == NULL) {
                     ui_icon_names[mt][i] = ui_find_icon_name(theme, volume_icon_names, i);
                 }
+                g_debug(g_strdup_printf("Using microphone icon %s", ui_icon_names[mt][i]));
             }
         }
         else {
             for(icon_idx_t i = 0; i < ICON_IDX_COUNT; i++) {
                 ui_icon_names[mt][i] = ui_find_icon_name(theme, volume_icon_names, i);
+                g_debug(g_strdup_printf("Using speaker icon %s", ui_icon_names[mt][i]));
             }
         }
     }

--- a/src/ui.c
+++ b/src/ui.c
@@ -156,23 +156,38 @@ GtkDialog* ui_errordialog(const gchar* title, const gchar* message)
     return GTK_DIALOG(dialog);
 }
 
-static const gchar* ui_find_icon_name(GtkIconTheme* theme, const gchar* name, const gchar* fallback)
+static const gchar* ui_find_icon_name(GtkIconTheme* theme, icon_set_t icons, icon_idx_t idx)
 {
-    const gchar* s = g_strdup_printf("%s-symbolic", name);
-    if(gtk_icon_theme_has_icon(theme, s))
-        return s;
-    g_free(s);
-    if(gtk_icon_theme_has_icon(theme, name))
-        return g_strdup(name);
-    return g_strdup(fallback);
+    while (idx < ICON_IDX_COUNT) {
+        g_debug(g_strdup_printf("Index: %d", idx));
+        const gchar* name = icons[idx];
+        const gchar* s = g_strdup_printf("%s-symbolic", name);
+        if(gtk_icon_theme_has_icon(theme, s))
+            return s;
+        g_free(s);
+        if(gtk_icon_theme_has_icon(theme, name))
+            return name;
+        idx++;
+    }
+    g_debug("NULL");
+    return NULL;
 }
 
 static void ui_load_icons(void) {
     GtkIconTheme* theme = gtk_icon_theme_get_default();
     for(menu_type_t mt = 0; mt < MENU_COUNT; mt++) {
-        const gchar** preferred_names = (mt == MENU_SOURCE ? mic_icon_names : volume_icon_names);
-        for(icon_idx_t i = 0; i < ICON_IDX_COUNT; i++) {
-            ui_icon_names[mt][i] = ui_find_icon_name(theme, preferred_names[i], volume_icon_names[i]);
+        if(mt == MENU_SOURCE) {
+            for(icon_idx_t i = 0; i < ICON_IDX_COUNT; i++) {
+                ui_icon_names[mt][i] = ui_find_icon_name(theme, mic_icon_names, i);
+                if(ui_icon_names[mt][i] == NULL) {
+                    ui_icon_names[mt][i] = ui_find_icon_name(theme, volume_icon_names, i);
+                }
+            }
+        }
+        else {
+            for(icon_idx_t i = 0; i < ICON_IDX_COUNT; i++) {
+                ui_icon_names[mt][i] = ui_find_icon_name(theme, volume_icon_names, i);
+            }
         }
     }
 }

--- a/src/ui.c
+++ b/src/ui.c
@@ -169,6 +169,7 @@ static const gchar* ui_find_icon_name(GtkIconTheme* theme, icon_set_t icons, ico
         idx++;
     }
     return NULL;
+}
 
 static void ui_load_icons(settings_t* settings) {
     GtkIconTheme* theme = gtk_icon_theme_get_default();

--- a/src/ui.c
+++ b/src/ui.c
@@ -1,3 +1,4 @@
+
 /***
   This file is part of PaSystray
 
@@ -27,17 +28,19 @@
 
 typedef enum {
     ICON_IDX_MUTED = 0,
-    ICON_IDX_LOW = 1,
-    ICON_IDX_MEDIUM = 2,
-    ICON_IDX_HIGH = 3
+    ICON_IDX_ZERO = 1,
+    ICON_IDX_LOW = 2,
+    ICON_IDX_MEDIUM = 3,
+    ICON_IDX_HIGH = 4
 } icon_idx_t;
 
-enum { ICON_IDX_COUNT = 4 };
+enum { ICON_IDX_COUNT = 5 };
 
 typedef const gchar* icon_set_t[ICON_IDX_COUNT];
 
 static icon_set_t volume_icon_names = {
     [ICON_IDX_MUTED] = "audio-volume-muted",
+    [ICON_IDX_ZERO] = "audio-volume-zero",
     [ICON_IDX_LOW] = "audio-volume-low",
     [ICON_IDX_MEDIUM] = "audio-volume-medium",
     [ICON_IDX_HIGH] = "audio-volume-high"
@@ -45,6 +48,7 @@ static icon_set_t volume_icon_names = {
 
 static icon_set_t mic_icon_names = {
     [ICON_IDX_MUTED] = "microphone-sensitivity-muted",
+    [ICON_IDX_ZERO] = "microphone-sensitivity-zero",
     [ICON_IDX_LOW] = "microphone-sensitivity-low",
     [ICON_IDX_MEDIUM] = "microphone-sensitivity-medium",
     [ICON_IDX_HIGH] = "microphone-sensitivity-high"
@@ -101,6 +105,8 @@ void ui_set_volume_icon(menu_info_item_t* mii)
 
     if(mii->mute)
         idx = ICON_IDX_MUTED;
+    else if(volume == 0)
+        idx = ICON_IDX_ZERO;
     else if(volume < (PA_VOLUME_NORM / 3))
         idx = ICON_IDX_LOW;
     else if(volume < (PA_VOLUME_NORM / 3 * 2))


### PR DESCRIPTION
Not sure this can be merged as is.
audio-volume-zero-symbolic.svg is not included in every icon theme and if it is absent, a placeholder for a missing icon (like a broken image frame) is displayed. Maybe it should be enabled with a feature flag or something?