### PR TITLE
Fix activate event callbacks

### DIFF
--- a/src/menu_info.c
+++ b/src/menu_info.c
@@ -528,6 +528,16 @@ void menu_info_item_activated(GtkWidget* item, menu_info_item_t* mii)
         return;
     }
 
+    GdkEvent *current_event = gtk_get_current_event();
+    if (current_event) {
+        GdkEventType type = current_event->type;
+        gdk_event_free(current_event);
+
+        /* Ignore activation if already handled by clicked callback */
+        if (type == GDK_BUTTON_PRESS || type == GDK_BUTTON_RELEASE)
+            return;
+    }
+
     g_debug("[menu_info] item activated: %s %s",
             menu_info_type_name(mii->menu_info->type),
             mii->name);

--- a/src/menu_info.c
+++ b/src/menu_info.c
@@ -473,7 +473,7 @@ void menu_info_subitem_update(menu_info_t* mi, uint32_t index, const char* name,
     g_free(label);
 
     if(active)
-        gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(item->widget), TRUE);
+        menu_info_subitem_set_active(item, TRUE);
 }
 
 menu_info_item_t* menu_info_item_get(menu_info_t* mi, uint32_t index)
@@ -503,6 +503,20 @@ gboolean desc_equal(gpointer key, gpointer value, gpointer user_data)
 menu_info_item_t* menu_info_item_get_by_desc(menu_info_t* mi, const char* desc)
 {
     return g_hash_table_find(mi->items, desc_equal, (gpointer)desc);
+}
+
+void menu_info_item_set_active(menu_info_item_t* mii, gboolean is_active)
+{
+    g_signal_handlers_block_by_func(mii->widget, G_CALLBACK(menu_info_item_activated), mii);
+    gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(mii->widget), is_active);
+    g_signal_handlers_unblock_by_func(mii->widget, G_CALLBACK(menu_info_item_activated), mii);
+}
+
+void menu_info_subitem_set_active(menu_info_item_t* mii, gboolean is_active)
+{
+    g_signal_handlers_block_by_func(mii->widget, G_CALLBACK(menu_info_subitem_activated), mii);
+    gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(mii->widget), is_active);
+    g_signal_handlers_unblock_by_func(mii->widget, G_CALLBACK(menu_info_subitem_activated), mii);
 }
 
 void menu_info_item_activated(GtkWidget* item, menu_info_item_t* mii)

--- a/src/menu_info.c
+++ b/src/menu_info.c
@@ -507,14 +507,14 @@ menu_info_item_t* menu_info_item_get_by_desc(menu_info_t* mi, const char* desc)
 
 void menu_info_item_activated(GtkWidget* item, menu_info_item_t* mii)
 {
-    if (GTK_IS_CHECK_MENU_ITEM(item)
-            && !gtk_check_menu_item_get_active(GTK_MENU_ITEM(item)))
+    if (!GTK_IS_CHECK_MENU_ITEM(item)
+            || !gtk_check_menu_item_get_active(GTK_CHECK_MENU_ITEM(item)))
     {
-        /* Ignore activation of deselected item  */
+        /* Ignore activation of submenus and deselected items */
         return;
     }
 
-    g_debug("[menu_info] subitem activated: %s %s",
+    g_debug("[menu_info] item activated: %s %s",
             menu_info_type_name(mii->menu_info->type),
             mii->name);
 
@@ -597,10 +597,10 @@ void menu_info_item_scrolled(GtkWidget* item, GdkEventScroll* event,
 
 void menu_info_subitem_activated(GtkWidget* item, menu_info_item_t* mii) {
 
-    if (GTK_IS_CHECK_MENU_ITEM(item)
-            && !gtk_check_menu_item_get_active(GTK_MENU_ITEM(item)))
+    if (!GTK_IS_CHECK_MENU_ITEM(item)
+            || !gtk_check_menu_item_get_active(GTK_CHECK_MENU_ITEM(item)))
     {
-        /* Ignore activation of deselected item  */
+        /* Ignore activation of submenus and deselected items */
         return;
     }
 

--- a/src/menu_info.h
+++ b/src/menu_info.h
@@ -130,6 +130,8 @@ void menu_info_subitem_update(menu_info_t* mi, uint32_t index, const char* name,
 menu_info_item_t* menu_info_item_get(menu_info_t* mi, uint32_t index);
 menu_info_item_t* menu_info_item_get_by_name(menu_info_t* mi, const char* name);
 menu_info_item_t* menu_info_item_get_by_desc(menu_info_t* mi, const char* desc);
+void menu_info_item_set_active(menu_info_item_t* mii, gboolean is_active);
+void menu_info_subitem_set_active(menu_info_item_t* mii, gboolean is_active);
 
 void menu_info_item_activated(GtkWidget* item, menu_info_item_t* mii);
 void menu_info_item_clicked(GtkWidget* item, GdkEventButton* event,

--- a/src/pulseaudio.c
+++ b/src/pulseaudio.c
@@ -352,7 +352,7 @@ void pulseaudio_change_default_item(menu_info_t* mi, const char* new_default)
     menu_info_item_t* item = menu_info_item_get_by_name(mi, new_default);
 
     if(item)
-        gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(item->widget), TRUE);
+        menu_info_item_set_active(item, TRUE);
 }
 
 void pulseaudio_sink_init_cb(pa_context* c, const pa_sink_info* i, int is_last, void* userdata)

--- a/src/pulseaudio_action.c
+++ b/src/pulseaudio_action.c
@@ -34,6 +34,9 @@ void pulseaudio_set_default(menu_info_item_t* mii)
 {
     pa_operation* o = NULL;
 
+    g_debug("[pulseaudio_action] set default %s to %s",
+            menu_info_type_name(mii->menu_info->type), mii->name);
+
     switch(mii->menu_info->type)
     {
         case MENU_SERVER:
@@ -133,7 +136,7 @@ void pulseaudio_move_success_cb(pa_context *c, int success, void *userdata)
 
 void pulseaudio_rename(menu_info_item_t* mii, const char* name)
 {
-    g_debug("rename %s '%s' to '%s'",
+    g_debug("[pulseaudio_action] rename %s '%s' to '%s'",
             menu_info_type_name(mii->menu_info->type), mii->desc, name);
 
     char *key = g_markup_printf_escaped("%s:%s", menu_info_type_name(mii->menu_info->type), mii->name);
@@ -157,7 +160,7 @@ void pulseaudio_rename_success_cb(pa_context *c, int success, void *userdata)
 
 void pulseaudio_volume(menu_info_item_t* mii, int inc)
 {
-    g_debug("pulseaudio_volume(%s, %i)", mii->name, inc);
+    g_debug("[pulseaudio_action] pulseaudio_volume(%s, %i)", mii->name, inc);
 
     /* increment/decrement in 2% steps */
     pa_cvolume* volume;
@@ -291,7 +294,7 @@ void pulseaudio_update_volume_notification(menu_info_item_t* mii)
 
 void pulseaudio_toggle_mute(menu_info_item_t* mii)
 {
-    g_debug("pulseaudio_toggle_mute(%s)", mii->name);
+    g_debug("[pulseaudio_action] pulseaudio_toggle_mute(%s)", mii->name);
 
     pa_operation* o = NULL;
 


### PR DESCRIPTION
A bunch of fixes for `activate` callbacks being invoked without user interaction and conflicting with `clicked` callbacks since https://github.com/christophgysin/pasystray/pull/121:

#### [Fix spurious "[menu_info] item activated: input (null)"](../commit/f2628f184eccb5df9543f02df6981c34fcb441df)

These would happen when descending into playback streams submenus. The fix is to ignore activation for anything that isn't a `CHECK_MENU_ITEM`.

(Also fixes related compile warning and debug logging.)

#### [Improve logging in pulseaudio_action.c](../commit/e57d5a9dc2b5aac7378fc21ad5430633a5673f08)

#### [Fix defaults being changed and streams moved without user interaction](../commit/0dba5f9a2d86c77f7af3668fa87838cc18af7ae0)

Since we added callbacks for the activate signal of menu items, `pulseaudio_set_default`, `pulseaudio_move_input_to_sink` and `pulseaudio_move_output_to_source` were getting called without any user interaction whenever we invoked `gtk_check_menu_item_set_active` in response to events from pulseaudio.

This interferes with automatic switching of default sinks/sources in wireplumber (and maybe also pulseaudio):

1. Disconnect bluetooth headphones.

2. We're notified that the default sink changed to laptop built-in audio, and to reflect this in the menus, `gtk_check_menu_item_set_active` is invoked which triggers the activate signal callback. This results in an invocation of `pulseaudio_set_default`.

3. Connect bluetooth headphones again.

4. Nothing happens because we've called `pulseaudio_set_default` earlier and wireplumber now thinks the laptop built-in audio is the preferred device and doesn't auto-switch to BT headphones.

The fix is to block our activate callback when invoking `gtk_check_menu_item_set_active`.

#### [Fix alt-click/right-click setting defaults in addition to muting](../commit/c4a5521bf8540521ded68fe02ac8db86e36e61b8)

Alt-click and right-click was only meant to mute a sink/source, not set it as default, but since we added callbacks for the activate signal of menu items, these clicks did both. Also, left-click would set the default sink/source twice—probably harmless, but fixed here as well.