### PR TITLE
Implement ayatana-appinidcator

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,8 @@ jobs:
           - { CC: gcc, CFLAGS: --std=c99, EXTRA_CONF: --disable-x11 }
           - { CC: gcc, CFLAGS: --std=c99, EXTRA_CONF: --disable-statusicon }
           - { CC: gcc, CFLAGS: --std=c99, EXTRA_CONF: --disable-appindicator}
+          - { CC: gcc, CFLAGS: --std=c99, EXTRA_CONF: --disable-ayatana-appindicator}
+          - { CC: gcc, CFLAGS: --std=c99, EXTRA_CONF: --disable-ayatana-appindicator --disable-appindicator}
           - { CC: gcc, CFLAGS: --std=c11 }
           - { CC: clang, CFLAGS: --std=c99 }
           - { CC: clang, CFLAGS: --std=c11 }
@@ -50,3 +52,48 @@ jobs:
       run: make
     - name: make test
       run: make test
+  build2:
+      runs-on: ubuntu-latest
+      strategy:
+        matrix:
+          env:
+            - { CC: gcc, CFLAGS: --std=c99 }
+            - { CC: gcc, CFLAGS: --std=c99, EXTRA_CONF: --with-gtk=2 }
+            - { CC: gcc, CFLAGS: --std=c99, EXTRA_CONF: --disable-avahi }
+            - { CC: gcc, CFLAGS: --std=c99, EXTRA_CONF: --disable-notify }
+            - { CC: gcc, CFLAGS: --std=c99, EXTRA_CONF: --disable-x11 }
+            - { CC: gcc, CFLAGS: --std=c99, EXTRA_CONF: --disable-statusicon }
+            - { CC: gcc, CFLAGS: --std=c99, EXTRA_CONF: --disable-appindicator}
+            - { CC: gcc, CFLAGS: --std=c99, EXTRA_CONF: --disable-ayatana-appindicator}
+            - { CC: gcc, CFLAGS: --std=c99, EXTRA_CONF: --disable-ayatana-appindicator --disable-appindicator}
+            - { CC: gcc, CFLAGS: --std=c11 }
+            - { CC: clang, CFLAGS: --std=c99 }
+            - { CC: clang, CFLAGS: --std=c11 }
+      env: ${{ matrix.env }}
+      steps:
+      - name: apt-get update
+        run: sudo apt-get update
+      - name: apt-get install
+        run: >
+          sudo apt-get install --no-install-recommends
+          libgtk2.0-dev
+          libgtk-3-dev
+          libpulse-dev
+          libnotify-dev
+          libayatana-appindicator3-dev
+      - name: CC version
+        run: $CC --version
+      - name: git checkout
+        uses: actions/checkout@v2
+      - name: autotools
+        run: |
+          aclocal
+          autoconf
+          autoheader
+          automake --add-missing
+      - name: configure
+        run: ./configure ${EXTRA_CONF:-} || (cat config.log; exit 1)
+      - name: make
+        run: make
+      - name: make test
+        run: make test

--- a/configure.ac
+++ b/configure.ac
@@ -139,6 +139,27 @@ AC_SUBST(HAVE_APPINDICATOR)
 AM_CONDITIONAL([HAVE_APPINDICATOR], [test "x$HAVE_APPINDICATOR" = x1])
 AS_IF([test "x$HAVE_APPINDICATOR" = x1], AC_DEFINE([HAVE_APPINDICATOR], 1,
       [Have AppIndicator?]))
+### optional libayatana-appindicator support ###################################
+AC_ARG_ENABLE([ayatana-appindicator],
+    AS_HELP_STRING([--disable-ayatana-appindicator], [Disable optional ayatana-appindicator support]))
+
+case ${with_gtk} in
+    2) AYATANA_APPINDICATOR_VERSION=ayatana-appindicator-0.1;;
+    3) AYATANA_APPINDICATOR_VERSION=ayatana-appindicator3-0.1;;
+esac
+AS_IF([test "x$enable_ayatana_appindicator" != xno],
+    [PKG_CHECK_MODULES(AYATANA_APPINDICATOR, [ $AYATANA_APPINDICATOR_VERSION ], HAVE_AYATANA_APPINDICATOR=1,
+                       HAVE_AYATANA_APPINDICATOR=0)], HAVE_AYATANA_APPINDICATOR=0)
+
+AS_IF([test "x$enable_ayatana_appindicator" = xyes && test "x$HAVE_APPINDICATOR" = x0],
+    [AC_MSG_ERROR([*** libappindicator not found])])
+
+AC_SUBST(AYATANA_APPINDICATOR_CFLAGS)
+AC_SUBST(AYATANA_APPINDICATOR_LIBS)
+AC_SUBST(HAVE_AYATANA_APPINDICATOR)
+AM_CONDITIONAL([HAVE_AYATANA_APPINDICATOR], [test "x$HAVE_AYATANA_APPINDICATOR" = x1])
+AS_IF([test "x$HAVE_AYATANA_APPINDICATOR" = x1], AC_DEFINE([HAVE_AYATANA_APPINDICATOR], 1,
+      [Have AyatanaAppIndicator?]))
 ################################################################################
 
 if test "x$GCC" = xyes -o "x$CLANG" = xyes; then

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -63,6 +63,7 @@ pasystray_LDADD = \
     $(NOTIFY_LIBS) \
     $(AVAHI_LIBS) \
     $(APPINDICATOR_LIBS) \
+    $(AYATANA_APPINDICATOR_LIBS) \
     $(X11_LIBS)
 
 pasystray_CFLAGS = \
@@ -72,6 +73,7 @@ pasystray_CFLAGS = \
     $(NOTIFY_CFLAGS) \
     $(AVAHI_CFLAGS) \
     $(APPINDICATOR_CFLAGS) \
+    $(AYATANA_APPINDICATOR_CFLAGS) \
     $(X11_CFLAGS) \
     -DG_LOG_DOMAIN=\"pasystray\" \
     -DGLADE_FILE=\"$(gladedir)/$(gladefile)\"

--- a/src/systray_impl.c
+++ b/src/systray_impl.c
@@ -24,9 +24,13 @@
 #include "config.h"
 #include "systray.h"
 
-#ifdef HAVE_APPINDICATOR
+#if defined(HAVE_APPINDICATOR) || defined(HAVE_AYATANA_APPINDICATOR)
 
+#ifdef HAVE_AYATANA_APPINDICATOR
+#include <libayatana-appindicator/app-indicator.h>
+#else
 #include <libappindicator/app-indicator.h>
+#endif
 
 static void systray_impl_scroll_cb(AppIndicator* appind, gint delta, GdkScrollDirection direction, gpointer userdata)
 {


### PR DESCRIPTION
(re-do of the pull request without the junk from my testing github decided to include last time!)

This implements libayatana-appindicator as an option besides libappindicator. Closes #172.

I added CI tests and a new build as libayatana-appindicator are libappindicator exclusive and you can only have one installed at a time, so the build2 (ayatana) is separate from build (appindiciator). I've never done this stuff before so if its not the correct way, sorry.


