### PR TITLE
Add port switching context menu to sources and sinks.

### DIFF
--- a/src/menu_info.c
+++ b/src/menu_info.c
@@ -143,6 +143,7 @@ void menu_info_item_init(menu_info_item_t* mii)
     mii->submenu = NULL;
     mii->context = NULL;
     mii->address = NULL;
+    mii->active_port = NULL;
 }
 
 void menu_info_item_destroy(menu_info_item_t* mii)
@@ -152,6 +153,7 @@ void menu_info_item_destroy(menu_info_item_t* mii)
     g_free(mii->volume);
     g_free(mii->icon);
     g_free(mii->address);
+    g_free(mii->active_port);
     g_free(mii);
 }
 
@@ -711,6 +713,12 @@ void menu_info_item_rename_error(menu_info_item_t* mii)
 
     gtk_dialog_run(dialog);
     gtk_widget_destroy(GTK_WIDGET(dialog));
+}
+
+void menu_info_item_set_port_cb(GtkWidget* item, GdkEventButton* event, void* userdata)
+{
+    port_callback_data_t* data = userdata;
+    pulseaudio_set_port(data->mii, data->port_name);
 }
 
 void menu_info_module_unload_cb(GtkWidget* item, GdkEventButton* event, void* userdata)

--- a/src/menu_info.h
+++ b/src/menu_info.h
@@ -98,6 +98,7 @@ struct menu_info_item_t_ {
     menu_info_t* menu_info;
     menu_info_t* submenu;
     GtkMenuShell* context;
+    char* active_port;
 };
 
 menu_infos_t* menu_infos_create(void);
@@ -147,6 +148,13 @@ void menu_info_item_move_all_cb(GtkWidget* item, GdkEventButton* event, void* us
 void menu_info_item_rename_cb(GtkWidget* item, GdkEventButton* event, void* userdata);
 void menu_info_item_rename_dialog(menu_info_item_t* mii);
 void menu_info_item_rename_error(menu_info_item_t* mii);
+
+typedef struct {
+    menu_info_item_t* mii;
+    char* port_name;
+} port_callback_data_t;
+
+void menu_info_item_set_port_cb(GtkWidget* item, GdkEventButton* event, void* userdata);
 
 void menu_info_module_unload_cb(GtkWidget* item, GdkEventButton* event, void* userdata);
 

--- a/src/pulseaudio_action.h
+++ b/src/pulseaudio_action.h
@@ -50,6 +50,9 @@ void pulseaudio_module_load_success_cb(pa_context *c, uint32_t idx, void *userda
 void pulseaudio_module_unload(menu_info_item_t* mii);
 void pulseaudio_module_unload_success_cb(pa_context *c, int success, void *userdata);
 
+void pulseaudio_set_port(menu_info_item_t* mii, const char* port_name);
+void pulseaudio_set_port_success_cb(pa_context *c, int success, void *userdata);
+
 void pulseaudio_terminate(void);
 
 #endif /* PASYSTRAY_PULSEAUDIO_ACTION_H */


### PR DESCRIPTION
This pull request adds support for switching audio ports (such as headphone or speaker outputs) directly from the context menu for PulseAudio sinks and sources.

Port menu shows:
  - All available ports with radio buttons
  - Active port is marked/selected
  - Unavailable ports are disabled (grayed out)

Context Menu Structure
```
  Right-click on Sink/Source:
  ├── Move all inputs/outputs here
  ├── Rename
  ├── ──────────────────
  └── Switch Port
      ├── ○ Headphones (active)
      ├── ○ Line Out
      └── ○ Speaker (unavailable - grayed)
```